### PR TITLE
feat: add simple tinyMCE adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,14 @@
         "vitest": "^0.29.8"
       },
       "peerDependencies": {
-        "@syncfusion/ej2-documenteditor": ">=22.1"
+        "@syncfusion/ej2-documenteditor": ">=22.1",
+        "tinymce": ">=6.5"
       },
       "peerDependenciesMeta": {
         "@syncfusion/ej2-documenteditor": {
+          "optional": true
+        },
+        "tinymce": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,10 +46,14 @@
     "vitest": "^0.29.8"
   },
   "peerDependencies": {
-    "@syncfusion/ej2-documenteditor": ">=22.1"
+    "@syncfusion/ej2-documenteditor": ">=22.1",
+    "tinymce": ">=6.5"
   },
   "peerDependenciesMeta": {
     "@syncfusion/ej2-documenteditor": {
+      "optional": true
+    },
+    "tinymce": {
       "optional": true
     }
   }

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -1,7 +1,7 @@
 import { IaraInference } from "../speech";
 
 export abstract class EditorAdapter {
-  constructor(protected _recognition: any) {
+  constructor(protected _editor: any, protected _recognition: any) {
     _recognition.addEventListener(
       "iaraSpeechRecognitionResult",
       (event: { detail: IaraInference }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./syncfusion";
+export * from "./tinymce";

--- a/src/syncfusion/index.ts
+++ b/src/syncfusion/index.ts
@@ -1,8 +1,4 @@
-import type {
-  DocumentEditor,
-  Editor,
-  EditorHistory,
-} from "@syncfusion/ej2-documenteditor";
+import type { Editor, EditorHistory } from "@syncfusion/ej2-documenteditor";
 import { EditorAdapter } from "../editor";
 import { IaraInference } from "../speech";
 

--- a/src/tinymce/index.ts
+++ b/src/tinymce/index.ts
@@ -36,7 +36,7 @@ export class IaraTinyMCEAdapter extends EditorAdapter implements EditorAdapter {
   }
 
   insertParagraph() {
-    this._editorAPI.execCommand("mceInsertNewLine");
+    this._editorAPI.execCommand("InsertParagraph");
   }
 
   insertText(text: string) {


### PR DESCRIPTION
This PR adds a very basic adapter for the tinyMCE v6 editor. It allows inserting inferences with paragraph support.