### PR TITLE
fix: prevent resetting selection on scroll click while recording

### DIFF
--- a/src/syncfusion/index.ts
+++ b/src/syncfusion/index.ts
@@ -88,11 +88,12 @@ export class IaraSyncfusionAdapter
 
     this._editorContainer.element.addEventListener("mousedown", event => {
       if (event.button === 1) {
-        this._resetSelection = true;
-        this._cursorSelection = new IaraSyncfusionSelectionManager(
-          this._editorContainer.documentEditor
-        );
-        event.preventDefault();
+        if (!this._selectionManager) {
+          this._resetSelection = true;
+          this._cursorSelection = new IaraSyncfusionSelectionManager(
+            this._editorContainer.documentEditor
+          );
+        }
         this._recognition.toggleRecording();
       }
     });


### PR DESCRIPTION
Este PR impede o reset da posição do cursor com clique no scroll durante uma gravação, evitando erro no local da inserção.
Resolve PRT-1849.