### PR TITLE
feat: replace command to navigation fields

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -43,7 +43,6 @@ export abstract class EditorAdapter {
     {
       key: "iaraSpeechRecognitionResult",
       callback: (event?: CustomEvent<IaraSpeechRecognitionDetail>) => {
-        console.log("EVENT", event?.detail);
         if (event?.detail && this.iaraRecognizes)
           this.insertInference(event.detail);
       },

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -23,6 +23,11 @@ export interface IaraEditorConfig {
 export abstract class EditorAdapter {
   public onIaraCommand?: (command: string) => void;
   public iaraRecognizes = true;
+  public selectedField: {
+    content: string;
+    title: string;
+    type: "Field" | "Mandatory" | "Optional";
+  } = { content: "", title: "", type: "Field" };
   protected abstract _styleManager: IaraEditorStyleManager;
   protected abstract _navigationFieldManager: IaraEditorNavigationFieldManager;
   protected static DefaultConfig: IaraEditorConfig = {
@@ -38,6 +43,7 @@ export abstract class EditorAdapter {
     {
       key: "iaraSpeechRecognitionResult",
       callback: (event?: CustomEvent<IaraSpeechRecognitionDetail>) => {
+        console.log("EVENT", event?.detail);
         if (event?.detail && this.iaraRecognizes)
           this.insertInference(event.detail);
       },
@@ -107,8 +113,15 @@ export abstract class EditorAdapter {
     return this._navigationFieldManager;
   }
 
+  private _getNavigationFieldDeleted(): void {
+    const { content, title, type } = this.selectedField;
+    if (this.selectedField.content)
+      this._navigationFieldManager.insertField(content, title, type);
+  }
+
   private _initCommands(): void {
     this._recognition.commands.add("iara copiar laudo", async () => {
+      this._getNavigationFieldDeleted();
       if (this.hasEmptyRequiredFields()) {
         this.onIaraCommand?.("required fields to copy");
         return;
@@ -118,6 +131,7 @@ export abstract class EditorAdapter {
       this.onIaraCommand?.("iara copiar laudo");
     });
     this._recognition.commands.add("iara finalizar laudo", async () => {
+      this._getNavigationFieldDeleted();
       if (this.hasEmptyRequiredFields()) {
         this.onIaraCommand?.("required fields to finish");
         return;
@@ -142,17 +156,21 @@ export abstract class EditorAdapter {
       this.print();
     });
     this._recognition.commands.add("iara próximo campo", () => {
+      this._getNavigationFieldDeleted();
       this._navigationFieldManager.nextField();
     });
     this._recognition.commands.add("iara campo anterior", () => {
+      this._getNavigationFieldDeleted();
       this._navigationFieldManager.previousField();
     });
     this._recognition.commands.add("next", () => {
+      this._getNavigationFieldDeleted();
       this._navigationFieldManager.nextField();
     });
     this._recognition.commands.add(
       `buscar (\\p{Letter}+)`,
       (detail, command, param, groups) => {
+        this._getNavigationFieldDeleted();
         try {
           this._navigationFieldManager.goToField(groups ? groups[1] : "");
         } catch (e) {

--- a/src/syncfusion/index.ts
+++ b/src/syncfusion/index.ts
@@ -498,6 +498,8 @@ export class IaraSyncfusionAdapter
   }
 
   private _handleFirstInference(): void {
+    this._getCurrrentNavigateFieldSelected(this._documentEditor.selection.text);
+
     if (this._documentEditor.selection.text.length) {
       this._documentEditor.editor.delete();
     }
@@ -551,5 +553,22 @@ export class IaraSyncfusionAdapter
     }
 
     return false;
+  }
+
+  private _getCurrrentNavigateFieldSelected(field: string): void {
+    if (field.match(/\[(.*)\]/)) {
+      const { title, content } =
+        this._navigationFieldManager.getTitleAndContent(field);
+
+      let type: "Field" | "Mandatory" | "Optional" = "Field";
+      if (content.includes("*")) type = "Mandatory";
+      if (content.includes("?")) type = "Optional";
+
+      this.selectedField = {
+        content,
+        title,
+        type,
+      };
+    } else this.selectedField = { content: "", title: "", type: "Field" };
   }
 }

--- a/src/syncfusion/navigationFields/index.ts
+++ b/src/syncfusion/navigationFields/index.ts
@@ -47,7 +47,7 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
   };
   isFirstNextNavigation = false;
   isFirstPreviousNavigation = false;
-  private _bookmarks: IaraBookmark[] = [];
+  bookmarks: IaraBookmark[] = [];
 
   private _previousBookmarksTitles: string[] = [];
 
@@ -94,13 +94,13 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
     this.updateBookmark(editorBookmarks);
     this.removeEmptyField(editorBookmarks);
     if (this.isFirstNextNavigation || this.isFirstPreviousNavigation) {
-      this.insertedBookmark = this._bookmarks.filter(
+      this.insertedBookmark = this.bookmarks.filter(
         bookmark =>
           bookmark.name === editorBookmarks[editorBookmarks.length - 1]
       )[0];
     }
     this.sortByPosition();
-    if (this._bookmarks.length > 1)
+    if (this.bookmarks.length > 1)
       this.getPreviousAndNext(this.currentSelectionOffset);
 
     if (setColor) this.setColor();
@@ -110,7 +110,7 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
 
   goToField(title: string): void | string {
     this._previousBookmarksTitles = [...this._previousBookmarksTitles, title];
-    const bookmarks = this._bookmarks.filter(
+    const bookmarks = this.bookmarks.filter(
       bookmark =>
         bookmark.title.toLowerCase() === title.toLowerCase() &&
         bookmark.title !== "Nome do campo" &&
@@ -225,7 +225,7 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
   }
 
   sortByPosition(): void {
-    this._bookmarks.sort(
+    this.bookmarks.sort(
       (
         currentOffset: { offset: { start: string; end: string } },
         nextOffset: { offset: { start: string; end: string } }
@@ -262,14 +262,14 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
   }
 
   popAndUpdate(bookmarkName: string, content: string, title: string): void {
-    const index = this._bookmarks.findIndex(item => item.name === bookmarkName);
+    const index = this.bookmarks.findIndex(item => item.name === bookmarkName);
     if (
       bookmarkName.includes("Field") ||
       bookmarkName.includes("Mandatory") ||
       bookmarkName.includes("Optional")
     ) {
       if (index !== -1) {
-        this._bookmarks = this._bookmarks.map(item => {
+        this.bookmarks = this.bookmarks.map(item => {
           if (item.name === bookmarkName) {
             return {
               name: bookmarkName,
@@ -284,8 +284,8 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
           return item;
         });
       } else {
-        this._bookmarks = [
-          ...this._bookmarks,
+        this.bookmarks = [
+          ...this.bookmarks,
           {
             name: bookmarkName,
             content,
@@ -301,7 +301,7 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
   }
 
   setColor() {
-    this._bookmarks.map(bookmark => {
+    this.bookmarks.map(bookmark => {
       this._documentEditor.selection.select(
         bookmark.offset.start,
         bookmark.offset.end
@@ -412,26 +412,25 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
   }
 
   removeEmptyField(editorBookmarks: string[]): void {
-    this._bookmarks = this._bookmarks.filter(item =>
+    this.bookmarks = this.bookmarks.filter(item =>
       editorBookmarks.includes(item.name)
     );
-    this._bookmarks = this._bookmarks.filter(bookmark => bookmark.title);
+    this.bookmarks = this.bookmarks.filter(bookmark => bookmark.title);
   }
 
   getPreviousAndNext(currentOffset: { start: string; end: string }): void {
-    const index = this._bookmarks.findIndex(
+    const index = this.bookmarks.findIndex(
       bookmark => this.findCurrentIndex(currentOffset, bookmark.offset) < 0
     );
 
-    const previousIndex = index <= 0 ? this._bookmarks.length - 1 : index - 1;
+    const previousIndex = index <= 0 ? this.bookmarks.length - 1 : index - 1;
 
     let previousField =
       index <= 0
-        ? this._bookmarks[previousIndex]
-        : this._bookmarks[previousIndex];
+        ? this.bookmarks[previousIndex]
+        : this.bookmarks[previousIndex];
 
-    const nextField =
-      index === -1 ? this._bookmarks[0] : this._bookmarks[index];
+    const nextField = index === -1 ? this.bookmarks[0] : this.bookmarks[index];
 
     previousField = this.checkIsSelectedAndUpdatePrevious(previousIndex);
 
@@ -461,7 +460,7 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
   }
 
   checkIsSelectedAndUpdatePrevious(previousIndex: number): IaraBookmark {
-    let selected = this._bookmarks[previousIndex];
+    let selected = this.bookmarks[previousIndex];
 
     const compareCurrentOffsetWithPreviousOffset =
       this.currentSelectionOffset.start &&
@@ -483,12 +482,12 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
       compareCurrentOffsetWithNextOffset ||
       compareCurrentOffsetWithSelecteOffset
     ) {
-      selected = this._bookmarks[previousIndex - 1];
+      selected = this.bookmarks[previousIndex - 1];
       return previousIndex <= 0
-        ? this._bookmarks[this._bookmarks.length - 1]
-        : this._bookmarks[previousIndex - 1];
+        ? this.bookmarks[this.bookmarks.length - 1]
+        : this.bookmarks[previousIndex - 1];
     }
-    return this._bookmarks[previousIndex];
+    return this.bookmarks[previousIndex];
   }
 
   getOffsetsAndSelect(name: string, excludeBookmarkStartEnd?: boolean): void {
@@ -536,7 +535,7 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
 
   clearReportToCopyContent(): void {
     this.getBookmarks(false);
-    this._bookmarks.filter(field => {
+    this.bookmarks.filter(field => {
       this.getOffsetsAndSelect(field.name);
       if (field.name.includes("Field")) {
         if (field.content && field.content !== "Escreva uma dica de texto") {
@@ -558,7 +557,7 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
 
   requiredFields(): boolean {
     this.getBookmarks(false);
-    const mandatoriesFields = this._bookmarks.filter(
+    const mandatoriesFields = this.bookmarks.filter(
       bookmark => bookmark.name.includes("Mandatory") && bookmark.title
     );
     if (mandatoriesFields.length) {


### PR DESCRIPTION
If a navigation field selected and is a command replace empty by a navigation field was deleted. Resolve PRT-2005