### PR TITLE
fix: redefine the style to get the style of the previous inference

### DIFF
--- a/src/syncfusion/bookmarks/index.ts
+++ b/src/syncfusion/bookmarks/index.ts
@@ -18,7 +18,6 @@ export class IaraSyncfusionBookmarkManager {
       this._documentEditor.selection.movePreviousPosition();
     }
     if (isFinalInference) this.getBookmarks();
-    console.log(this._bookmarks, "BOOKS");
   }
 
   getBookmarks(): void {

--- a/src/syncfusion/bookmarks/index.ts
+++ b/src/syncfusion/bookmarks/index.ts
@@ -6,30 +6,19 @@ export class IaraSyncfusionBookmarkManager {
   private _bookmarks: { name: string; content: string; inferenceId: string }[] =
     [];
 
-  constructor(
-    private _documentEditor: DocumentEditor,
-    private _config: IaraSyncfusionConfig
-  ) {}
+  constructor(private _documentEditor: DocumentEditor) {}
 
   insertInferenceField(
     isFirstInference: boolean,
     isFinalInference: boolean
   ): void {
     if (isFirstInference) {
+      this._documentEditor.editor.insertText(" ");
       this._documentEditor.editor.insertBookmark(`inferenceId_${uuidv4()}`);
-      if (this._config.highlightInference) {
-        this._config.darkMode
-          ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            //@ts-ignore
-            (this._documentEditor.selection.characterFormat.highlightColor =
-              "#0e5836")
-          : // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            //@ts-ignore
-            (this._documentEditor.selection.characterFormat.highlightColor =
-              "#ccffe5");
-      }
+      this._documentEditor.selection.movePreviousPosition();
     }
     if (isFinalInference) this.getBookmarks();
+    console.log(this._bookmarks, "BOOKS");
   }
 
   getBookmarks(): void {

--- a/src/syncfusion/bookmarks/index.ts
+++ b/src/syncfusion/bookmarks/index.ts
@@ -1,5 +1,4 @@
 import { DocumentEditor } from "@syncfusion/ej2-documenteditor";
-import { IaraSyncfusionConfig } from "..";
 import { v4 as uuidv4 } from "uuid";
 
 export class IaraSyncfusionBookmarkManager {

--- a/src/syncfusion/selection.ts
+++ b/src/syncfusion/selection.ts
@@ -5,6 +5,7 @@ import type {
   Strikethrough,
   Underline,
 } from "@syncfusion/ej2-documenteditor";
+import { IaraSyncfusionConfig } from ".";
 
 interface SelectionData {
   characterFormat: SelectionCharacterFormatData;
@@ -31,8 +32,13 @@ export class IaraSyncfusionSelectionManager {
   public wordBeforeSelection = "";
   public isAtStartOfLine = false;
 
-  constructor(private _editor: DocumentEditor, getSurrondingWords = true) {
+  constructor(
+    private _editor: DocumentEditor,
+    private _config: IaraSyncfusionConfig,
+    getSurrondingWords = true
+  ) {
     const characterFormat = this._editor.selection.characterFormat;
+    this._inferencehighlightColor();
     this.initialSelectionData = {
       characterFormat: {
         allCaps: characterFormat.allCaps,
@@ -95,29 +101,45 @@ export class IaraSyncfusionSelectionManager {
     return wordBefore;
   }
 
+  private _inferencehighlightColor(): void {
+    if (this._config.highlightInference) {
+      this._config.darkMode
+        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          (this._editor.selection.characterFormat.highlightColor = "#0e5836")
+        : // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          (this._editor.selection.characterFormat.highlightColor = "#ccffe5");
+    }
+  }
+
   public resetSelection(resetStyles = true): void {
     this._editor.selection.select(
       this.initialSelectionData.startOffset,
       this.initialSelectionData.endOffset
     );
     if (resetStyles) {
-      const charFormatProps: (keyof SelectionCharacterFormatData)[] = [
-        "allCaps",
-        "baselineAlignment",
-        "bold",
-        "fontColor",
-        "fontFamily",
-        "fontSize",
-        "highlightColor",
-        "italic",
-        "strikethrough",
-        "underline",
-      ];
-
-      charFormatProps.forEach(prop => {
-        (this._editor.selection.characterFormat as any)[prop] =
-          this.initialSelectionData.characterFormat[prop];
-      });
+      this.resetStyles();
     }
+  }
+
+  public resetStyles(): void {
+    const charFormatProps: (keyof SelectionCharacterFormatData)[] = [
+      "allCaps",
+      "baselineAlignment",
+      "bold",
+      "fontColor",
+      "fontFamily",
+      "fontSize",
+      "highlightColor",
+      "italic",
+      "strikethrough",
+      "underline",
+    ];
+
+    charFormatProps.forEach(prop => {
+      (this._editor.selection.characterFormat as any)[prop] =
+        this.initialSelectionData.characterFormat[prop];
+    });
   }
 }

--- a/src/syncfusion/style.ts
+++ b/src/syncfusion/style.ts
@@ -23,7 +23,7 @@ export class IaraSyncfusionStyleManager extends IaraEditorStyleManager {
     });
 
     // this.zoomInterval = setInterval(() => {
-      this.setZoomFactor(this._config.zoomFactor ?? "100%");
+    this.setZoomFactor(this._config.zoomFactor ?? "100%");
     // }, 100);
   }
 


### PR DESCRIPTION
The insertion of the bookmark caused a reset of the selection which undid the previous stylization. Redefine the style to get the style of the previous inference. Resolve PRT-2054