### PR TITLE
fix: compare transcipt with command

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -197,6 +197,21 @@ export abstract class EditorAdapter {
         }
       }
     );
+    this._recognition.commands.add(
+      `campo (\\p{Letter}+)`,
+      (detail, command, param, groups) => {
+        if (detail.transcript === (groups?.length && groups[0])) {
+          this._getNavigationFieldDeleted();
+        }
+        try {
+          this._navigationFieldManager.goToField(groups ? groups[1] : "");
+        } catch (e) {
+          this.onIaraCommand?.("buscar");
+        } finally {
+          console.info(detail, command, param);
+        }
+      }
+    );
   }
 
   private _initListeners(): void {

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -185,7 +185,7 @@ export abstract class EditorAdapter {
     this._recognition.commands.add(
       `buscar (\\p{Letter}+)`,
       (detail, command, param, groups) => {
-        if (detail.transcript === command) {
+        if (detail.transcript === (groups?.length && groups[0])) {
           this._getNavigationFieldDeleted();
         }
         try {


### PR DESCRIPTION
In the case of the  "buscar (\\p{Letter}+)" command, it is necessary to change the comparison to be through the group because the command is a regex and will never be the same as what was transcribed