### PR TITLE
fix: removed unused functions in navigation commands

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -181,18 +181,13 @@ export abstract class EditorAdapter {
     this._recognition.commands.add(this._locale.nextField, (detail, command) => {
       if (detail.transcript === command) this._handleRemovedNavigationField();
       this._navigationFieldManager.nextField();
-      this._onIaraCommand(this._locale.nextField);
     });
     this._recognition.commands.add(this._locale.previousField, (detail, command) => {
       if (detail.transcript === command) this._handleRemovedNavigationField();
-      this._onIaraCommand(this._locale.previousField);
       this._navigationFieldManager.previousField();
     });
-    this._recognition.commands.add(
-      this._locale.next,
-      (detail, command) => {
+    this._recognition.commands.add(this._locale.next, (detail, command) => {
         if (detail.transcript === command) this._handleRemovedNavigationField();
-        this._onIaraCommand(this._locale.next);
         this._navigationFieldManager.nextField();
       }
     );


### PR DESCRIPTION
It was necessary to remove the this._onIaraCommand function because not only was it not used in the case of navigation commands, it was causing the bookmark selection to be lost. Resolve PRT-2101