### PR TITLE
fix: middle button click missing selection text value

### DIFF
--- a/src/syncfusion/index.ts
+++ b/src/syncfusion/index.ts
@@ -512,7 +512,6 @@ export class IaraSyncfusionAdapter
     this._documentEditor.getRootElement().addEventListener("mouseup", event => {
       if (event.button === 1) {
         this._cursorSelection?.resetSelection();
-        this._cursorSelection?.destroy();
         this._cursorSelection = undefined;
 
         this._recognition.toggleRecording();


### PR DESCRIPTION
Selection text value is lost when the middle button is clicked.  Resolve PRT-2104