### PR TITLE
fix: in case of selection don´t remove space

### DIFF
--- a/src/syncfusion/index.ts
+++ b/src/syncfusion/index.ts
@@ -539,9 +539,10 @@ export class IaraSyncfusionAdapter
 
   private _handleFirstInference(inference: IaraSpeechRecognitionDetail): void {
     this._updateSelectedNavigationField(this._documentEditor.selection.text);
+    const hasSelectedText = this._documentEditor.selection.text.length
 
     if (this._documentEditor.selection.text.length) {
-      this._documentEditor.editor.delete();
+        this._documentEditor.editor.delete();
     }
 
     this._selectionManager = new IaraSyncfusionSelectionManager(
@@ -565,8 +566,10 @@ export class IaraSyncfusionAdapter
       this._selectionManager.moveSelectionToBeforeBookmarkEdge(
         this._selectionManager.initialSelectionData.bookmarkId
       );
-      this._documentEditor.selection.extendBackward();
-      this._documentEditor.editor.delete();
+      if (!hasSelectedText) {
+        this._documentEditor.selection.extendBackward();
+        this._documentEditor.editor.delete();
+      }
       this._selectionManager.resetSelection();
     }
   }

--- a/src/syncfusion/index.ts
+++ b/src/syncfusion/index.ts
@@ -539,9 +539,9 @@ export class IaraSyncfusionAdapter
 
   private _handleFirstInference(inference: IaraSpeechRecognitionDetail): void {
     this._updateSelectedNavigationField(this._documentEditor.selection.text);
-    const hasSelectedText = this._documentEditor.selection.text.length
+    const hadSelectedText = this._documentEditor.selection.text.length
 
-    if (this._documentEditor.selection.text.length) {
+    if (hadSelectedText) {
         this._documentEditor.editor.delete();
     }
 
@@ -566,7 +566,7 @@ export class IaraSyncfusionAdapter
       this._selectionManager.moveSelectionToBeforeBookmarkEdge(
         this._selectionManager.initialSelectionData.bookmarkId
       );
-      if (!hasSelectedText) {
+      if (!hadSelectedText) {
         this._documentEditor.selection.extendBackward();
         this._documentEditor.editor.delete();
       }


### PR DESCRIPTION
In the case of selection, do not remove the space when the previous word is a space. Resolve PRT-2105 