### PR TITLE
Bugfix/prt 2108

### DIFF
--- a/src/syncfusion/navigationFields/index.ts
+++ b/src/syncfusion/navigationFields/index.ts
@@ -75,7 +75,6 @@ export class IaraSyncfusionNavigationFieldManager extends IaraEditorNavigationFi
     type: "Field" | "Mandatory" | "Optional" = "Field"
   ): void {
     const bookmarksCount = uuidv4();
-    this._documentEditor.editor.insertText(" ");
     this._documentEditor.selection.movePreviousPosition();
     this._documentEditor.editor.insertBookmark(`${type}-${bookmarksCount}`);
     this._documentEditor.editor.insertText("[]");


### PR DESCRIPTION
Removed a space is added right after the created field, which sometimes (when creating a navigation field from selected content) will result in two spaces in sequence after the navigation field. Resolve PRT-2108