### PR TITLE
fix: remove enableSpeechRecognition true when close the assistant

### DIFF
--- a/src/syncfusion/assistant/assistant.ts
+++ b/src/syncfusion/assistant/assistant.ts
@@ -121,15 +121,11 @@ export class IaraSyncfusionAIAssistant {
       );
     });
 
-    // Disable speech recognition while assistant is open,
-    // and re-enable it when the assistant is closed (if it was enabled before)
-    const enableSpeechRecognition = this._config.enableSpeechRecognition;
     this._config.enableSpeechRecognition = false;
     assistant.addEventListener("action", (event: Event) => {
       const detail = (event as CustomEvent).detail;
       if (detail.id == "close") {
         dispatchEvent(new CustomEvent("IaraAssistantClosed"));
-        this._config.enableSpeechRecognition = enableSpeechRecognition;
         this._editor.isReadOnly = false;
         assistant.remove();
       }

--- a/src/syncfusion/assistant/assistant.ts
+++ b/src/syncfusion/assistant/assistant.ts
@@ -92,7 +92,6 @@ export class IaraSyncfusionAIAssistant {
       this._insertReport(detail.report);
       this._insertDiagnosticImpression(detail.impression);
       dispatchEvent(new CustomEvent("IaraAssistantReport", { detail }));
-      this._recognition.start();
     });
 
     assistant.addEventListener("definedSettings", (event: Event) => {
@@ -121,7 +120,6 @@ export class IaraSyncfusionAIAssistant {
       );
     });
 
-    this._config.enableSpeechRecognition = false;
     assistant.addEventListener("action", (event: Event) => {
       const detail = (event as CustomEvent).detail;
       if (detail.id == "close") {


### PR DESCRIPTION
Fix: remove enableSpeechRecognition true when closing the ai assistant, so that recognition is not enabled again. Resolve PRT-2353