### PR TITLE
fix: bugfix/PRT-2361

### DIFF
--- a/src/syncfusion/index.ts
+++ b/src/syncfusion/index.ts
@@ -603,6 +603,7 @@ export class IaraSyncfusionAdapter
         if (!this.config.assistant.enabled) return;
         this._onIaraCommand(this._locale.openAssistant);
         this._isEditorCommandBlocked.blocked = true;
+        this._recognition.stop();
         new IaraSyncfusionAIAssistant(
           this.documentEditor,
           this._recognition,


### PR DESCRIPTION
Fix: interrupt recognition before the assistant opens, thus closing the instance before recognition starts again. Resolve PRT-2361